### PR TITLE
Server support for Describe

### DIFF
--- a/src/main/kotlin/gonorth/Client.kt
+++ b/src/main/kotlin/gonorth/Client.kt
@@ -28,7 +28,7 @@ interface GameClient {
 class SpikeGameClient(var db: Map<String, GameState>, val engine: GoNorth) : GameClient {
     override fun takeInput(userId: String, input: String): Option<GameState> {
 
-        val moveOpt = input.substringAfter(' ')
+        //val moveOpt = input.substringAfter(' ')
         val command = input.substringBefore(" ")
 
 

--- a/src/main/kotlin/gonorth/Client.kt
+++ b/src/main/kotlin/gonorth/Client.kt
@@ -27,12 +27,12 @@ interface GameClient {
 
 class SpikeGameClient(var db: Map<String, GameState>, val engine: GoNorth) : GameClient {
     override fun takeInput(userId: String, input: String): Option<GameState> {
-
-        //val moveOpt = input.substringAfter(' ')
+        // /gnad EAST
+        // /gnad DESCRIBE Key
+        val moveOpt = input.substringAfter(' ')
         val command = input.substringBefore(" ")
 
-
-        val commandOpt = if (command == input) {
+        val commandOpt = if (command == moveOpt) {
             Option.None
         } else {
             Option.Some(command)
@@ -41,7 +41,7 @@ class SpikeGameClient(var db: Map<String, GameState>, val engine: GoNorth) : Gam
         val res = db[userId].toOpt()
                 .flatMap { gs ->
                     Move.values()
-                            .find { m -> m.name == input }
+                            .find { m -> m.name == moveOpt }
                             .toOpt()
                             .map { engine.takeAnyAction(gs, it, commandOpt)  }
                 }

--- a/src/main/kotlin/gonorth/Client.kt
+++ b/src/main/kotlin/gonorth/Client.kt
@@ -29,19 +29,20 @@ class SimpleGameClient(var db: Map<String, GameState>, val engine: GoNorth, val 
     override fun takeInput(userId: String, input: String): Option<GameState> {
         // /gnad EAST
         // /gnad DESCRIBE Key
-        val moveOpt = input.substringAfter(' ')
-        val command = input.substringBefore(" ")
+        val moveStr = input.substringBefore(' ')
+        val command = input.substringAfter(" ")
 
-        val commandOpt = if (command == moveOpt) {
+        val commandOpt = if (command == moveStr) {
             Option.None
         } else {
             Option.Some(command)
         }
 
+
         val res = db[userId].toOpt()
                 .flatMap { gs ->
                     Move.values()
-                            .find { m -> m.name == moveOpt }
+                            .find { m -> m.name == moveStr }
                             .toOpt()
                             .map { engine.takeAnyAction(gs, it, commandOpt)  }
                 }
@@ -158,6 +159,28 @@ class SimpleWorldGenerator : gonorth.WorldGenerator {
                         "As you head west, you ponder whether println can print strings")
                 .linkLocation(p1, p3, Move.NORTH, "You stumble ahead")
                 .linkLocation(p6, p7, Move.NORTH, "You head north towards the tower")
+                .world
+
+        val startingText = GameText(
+                "You find yourself lost in a dark forest.",
+                Option.Some("It might be wise to find shelter for the night.")
+        )
+
+        return GameState(startingText, world, p1.id)
+    }
+}
+
+class TinyWorldGenerator : gonorth.WorldGenerator {
+    override fun generate(): GameState {
+        val key = Item("Key", "Shiny key, looks useful")
+
+        val p1 = Location(UUID.randomUUID(), "There is a fork in the path. A key rests on the ground", setOf(key))
+        val p3 = Location(UUID.randomUUID(), "You went north and died.", emptySet())
+
+
+        val world = WorldBuilder().newLocation(p1)
+                .newLocation(p3)
+                .linkLocation(p1, p3, Move.NORTH, "You stumble ahead")
                 .world
 
         val startingText = GameText(

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -7,6 +7,14 @@ import java.util.*
 
 class GoNorth {
 
+    fun takeAnyAction(gameState: GameState, move: Move, command: Option<String>): GameState {
+        return if (movementActions.contains(move) && command.isEmpty) {
+            takeAction(gameState, move) x
+        } else if (movementActions.contains(move) && command.nonEmpty()) {
+            takeActionWithTarget(gameState, move, command.getOrElse { "" })
+        } else gameState
+    }
+
     fun takeAction(gameState: GameState, move: Move): GameState {
         return if (movementActions.contains(move)) {
             handleMovement(gameState, move).getOrElse { gameState }

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -8,9 +8,10 @@ import java.util.*
 class GoNorth {
 
     fun takeAnyAction(gameState: GameState, move: Move, command: Option<String>): GameState {
-        return if (movementActions.contains(move) && command.isEmpty) {
+        println("Taking action $move ${command.getOrElse { "" }}")
+        return if (movementActions.contains(move)) {
             takeAction(gameState, move)
-        } else if (movementActions.contains(move) && command.nonEmpty()) {
+        } else if (command.nonEmpty()) {
             takeActionWithTarget(gameState, move, command.getOrElse { "" })
         } else gameState
     }

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -9,7 +9,7 @@ class GoNorth {
 
     fun takeAnyAction(gameState: GameState, move: Move, command: Option<String>): GameState {
         return if (movementActions.contains(move) && command.isEmpty) {
-            takeAction(gameState, move) x
+            takeAction(gameState, move)
         } else if (movementActions.contains(move) && command.nonEmpty()) {
             takeActionWithTarget(gameState, move, command.getOrElse { "" })
         } else gameState

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -1,14 +1,18 @@
 package gonorth
 
-import gonorth.domain.*
-import kategory.*
-import kategory.Option.*
+import gonorth.domain.Move
+import gonorth.domain.World
+import gonorth.domain.locationOpt
+import kategory.Option
+import kategory.Option.None
+import kategory.Option.Some
+import kategory.getOrElse
+import kategory.nonEmpty
 import java.util.*
 
 class GoNorth {
 
     fun takeAnyAction(gameState: GameState, move: Move, command: Option<String>): GameState {
-        println("Taking action $move ${command.getOrElse { "" }}")
         return if (movementActions.contains(move)) {
             takeAction(gameState, move)
         } else if (command.nonEmpty()) {

--- a/src/main/kotlin/gonorth/slack/SlackServer.kt
+++ b/src/main/kotlin/gonorth/slack/SlackServer.kt
@@ -59,7 +59,6 @@ fun Application.module() {
                                     .map { it.move.name }
                             SlackResponse(g.preText.preText + "\n" +
                                     g.preText.description.map { it + "\n"}.getOrElse { "" } +
-//                                    g.location()?.description + "\n" +
                                     mvs)
                         }
 
@@ -83,7 +82,6 @@ fun Application.module() {
 
                 val userOpt: Option<String> = formData["user_id"].toOpt()
                 val textOpt: Option<String> = formData["text"].toOpt()
-
 
                 val sr = userOpt
                         .flatMap { u ->

--- a/src/main/kotlin/gonorth/slack/SlackServer.kt
+++ b/src/main/kotlin/gonorth/slack/SlackServer.kt
@@ -1,18 +1,19 @@
 package gonorth.slack
 
 import com.fasterxml.jackson.databind.SerializationFeature
-import gonorth.SimpleWorldGenerator
 import gonorth.GoNorth
 import gonorth.SimpleGameClient
-import gonorth.domain.location
-import io.ktor.application.*
+import gonorth.SimpleWorldGenerator
+import io.ktor.application.Application
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.application.log
 import io.ktor.features.CallLogging
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.jackson.jackson
-import io.ktor.pipeline.PipelineContext
 import io.ktor.request.contentType
 import io.ktor.request.receiveParameters
 import io.ktor.response.respond
@@ -23,7 +24,6 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kategory.Option
-import kategory.empty
 import kategory.getOrElse
 
 fun main(args: Array<String>) {
@@ -45,11 +45,11 @@ fun Application.module() {
         }
     }
     routing {
-        get("/") {
+        get("/health") {
             call.respondText("Hello, world!", ContentType.Text.Html)
         }
         post("create") {
-
+            log.info("Request made to create endpoint")
             if (call.request.contentType() == ContentType.Application.FormUrlEncoded) {
                 val formData = call.receiveParameters()
 
@@ -85,8 +85,6 @@ fun Application.module() {
                 call.respond(HttpStatusCode.BadRequest)
             }
         }
-
-
     }
 }
 

--- a/src/main/kotlin/gonorth/slack/SlackService.kt
+++ b/src/main/kotlin/gonorth/slack/SlackService.kt
@@ -1,6 +1,7 @@
 package gonorth.slack
 
 import gonorth.GameClient
+import gonorth.domain.locationOpt
 import kategory.Option
 import kategory.getOrElse
 
@@ -14,6 +15,7 @@ class SlackService(private val client: GameClient) {
                             .map { it.move.name }
                     SlackResponse(g.preText.preText + "\n" +
                             g.preText.description.map { it + "\n" }.getOrElse { "" } +
+                            g.locationOpt().map { it.description.plus("\n")}.getOrElse {""} +
                             mvs)
                 }
     }

--- a/src/main/kotlin/gonorth/slack/SlackService.kt
+++ b/src/main/kotlin/gonorth/slack/SlackService.kt
@@ -1,0 +1,45 @@
+package gonorth.slack
+
+import gonorth.GameClient
+import gonorth.domain.location
+import kategory.Option
+import kategory.getOrElse
+
+class SlackService(val client: GameClient) {
+
+    fun createGame(user: Option<String>): Option<SlackResponse> {
+        return user.map { u -> client.startGame(u) }
+                .map { g ->
+                    val mvs: List<String> = g.world.links
+                            .getOrDefault(g.currentLocation, emptySet())
+                            .map { it.move.name }
+                    SlackResponse(g.preText.preText + "\n" +
+                            g.preText.description.map { it + "\n" }.getOrElse { "" } +
+                            mvs)
+                }
+    }
+
+    fun takeInput(user: Option<String>, input: Option<String>): Option<SlackResponse> {
+        return user
+                .flatMap { u ->
+                    input.flatMap { t -> client.takeInput(u, t) }
+                }
+                .map { g ->
+
+                    val mvs: List<String> = g.world.links
+                            .getOrDefault(g.currentLocation, emptySet())
+                            .map { it.move.name }
+
+                    if (mvs.isEmpty()) {
+                        SlackResponse(g.preText.preText + "\n" +
+                                g.preText.description.map { it + "\n" }.getOrElse { "" } +
+                                g.location()?.description)
+                    } else {
+                        SlackResponse(g.preText.preText + "\n" +
+                                g.preText.description.map { it + "\n" }.getOrElse { "" } +
+                                g.location()?.description + "\n" +
+                                mvs)
+                    }
+                }
+    }
+}

--- a/src/main/kotlin/gonorth/slack/SlackService.kt
+++ b/src/main/kotlin/gonorth/slack/SlackService.kt
@@ -1,11 +1,10 @@
 package gonorth.slack
 
 import gonorth.GameClient
-import gonorth.domain.location
 import kategory.Option
 import kategory.getOrElse
 
-class SlackService(val client: GameClient) {
+class SlackService(private val client: GameClient) {
 
     fun createGame(user: Option<String>): Option<SlackResponse> {
         return user.map { u -> client.startGame(u) }
@@ -32,12 +31,10 @@ class SlackService(val client: GameClient) {
 
                     if (mvs.isEmpty()) {
                         SlackResponse(g.preText.preText + "\n" +
-                                g.preText.description.map { it + "\n" }.getOrElse { "" } +
-                                g.location()?.description)
+                                g.preText.description.map { it + "\n" }.getOrElse { "" })
                     } else {
                         SlackResponse(g.preText.preText + "\n" +
                                 g.preText.description.map { it + "\n" }.getOrElse { "" } +
-                                g.location()?.description + "\n" +
                                 mvs)
                     }
                 }

--- a/src/main/kotlin/gonorth/world/WorldBuilder.kt
+++ b/src/main/kotlin/gonorth/world/WorldBuilder.kt
@@ -1,7 +1,6 @@
 package gonorth.world
 
 import gonorth.domain.*
-import gonorth.slack.toOpt
 import kategory.getOption
 
 // gonorth.domain.World data structure and building functions

--- a/src/test/kotlin/WorldBuilderTest.kt
+++ b/src/test/kotlin/WorldBuilderTest.kt
@@ -1,11 +1,11 @@
 import gonorth.domain.Item
 import gonorth.domain.Location
+import gonorth.domain.Move
 import gonorth.world.WorldBuilder
 import org.junit.Test
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import gonorth.domain.Move
-import java.util.*
 
 class WorldBuilderTest {
 

--- a/src/test/kotlin/gonorth/GoNorthTest.kt
+++ b/src/test/kotlin/gonorth/GoNorthTest.kt
@@ -1,17 +1,16 @@
 package gonorth
 
 import gonorth.domain.Item
-import gonorth.domain.Move.*
-import gonorth.world.WorldBuilder
-
 import gonorth.domain.Location
-import org.junit.Test
-import java.util.*
-import kotlin.test.assertEquals
+import gonorth.domain.Move.*
 import gonorth.domain.location
+import gonorth.world.WorldBuilder
 import kategory.Option
 import kategory.getOrElse
 import kategory.some
+import org.junit.Test
+import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/gonorth/GoNorthTest.kt
+++ b/src/test/kotlin/gonorth/GoNorthTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 import gonorth.domain.location
 import kategory.Option
 import kategory.getOrElse
+import kategory.some
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -83,6 +84,20 @@ class GoNorthTest {
                 .world
         val testGameState = gameState.copy(world = testWorld)
         val newState = goNorth.takeActionWithTarget(testGameState, DESCRIBE, "Fox")
+
+        assertEquals("You take a closer look.", newState.preText.preText)
+
+        assertEquals("There is no Fox", newState.preText.description.getOrElse { "" })
+        assertTrue(newState.world.links.containsKey(newState.location()?.id))
+    }
+
+    @Test
+    fun canDescribeATargetUsingTheHelperMethod() {
+        val testWorld = builder
+                .placeItem(location1, Item("Key", "It's a shiny golden key."))
+                .world
+        val testGameState = gameState.copy(world = testWorld)
+        val newState = goNorth.takeAnyAction(testGameState, DESCRIBE, "Fox".some())
 
         assertEquals("You take a closer look.", newState.preText.preText)
 

--- a/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
+++ b/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
@@ -28,7 +28,7 @@ class SimpleGameClientTest {
 
     @Test
     fun takeInputShouldMoveThePlayerWhenGivenAValidDirection() {
-        val user = "Jones"
+        val user = "Davey"
         val textOpt = "NORTH"
         val createdGame: GameState = gameClient.startGame(user)
         val resultOpt: Option<GameState> = gameClient.takeInput(user, textOpt)

--- a/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
+++ b/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
@@ -1,11 +1,13 @@
 package gonorth.slack
 
 import gonorth.*
+import gonorth.domain.Move
 import gonorth.domain.location
 import kategory.Option
 import kategory.getOrElse
 import kategory.nonEmpty
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -13,7 +15,7 @@ import kotlin.test.assertTrue
 class SimpleGameClientTest {
 
     val goNorth = GoNorth()
-    val gameClient: GameClient = SimpleGameClient(emptyMap(), goNorth, SimpleWorldGenerator())
+    val gameClient: GameClient = SimpleGameClient(emptyMap(), goNorth, TinyWorldGenerator())
 
     @Test
     fun createShouldCreateANewGameWhenGivenValidInput() {
@@ -45,6 +47,29 @@ class SimpleGameClientTest {
         assertNotEquals(resultText.preText, resultText.description.getOrElse { "" })
 
         assertNotEquals(createdGame.location(), result.location())
+    }
+
+    @Test
+    fun takeInputShouldHandleAValidCommandRequest() {
+        val user = "Jones"
+        val textOpt = "${Move.DESCRIBE.name} Key"
+        val createdGame: GameState = gameClient.startGame(user)
+        val resultOpt: Option<GameState> = gameClient.takeInput(user, textOpt)
+        val result = resultOpt.getOrElse { createdGame }
+
+        assertTrue { resultOpt.nonEmpty() }
+        assertNotEquals(createdGame, result)
+
+        val initialText = createdGame.preText
+        val resultText = result.preText
+
+        assertTrue(resultText.preText.isNotEmpty())
+        assertNotEquals(initialText.preText, resultText.preText)
+        assertNotEquals(initialText.description, resultText.description)
+        assertTrue(resultText.description.getOrElse { "" }.isNotEmpty())
+        assertNotEquals(resultText.preText, resultText.description.getOrElse { "" })
+
+        assertEquals(createdGame.location(), result.location())
     }
 
 }

--- a/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
+++ b/src/test/kotlin/gonorth/slack/SimpleGameClientTest.kt
@@ -1,0 +1,51 @@
+package gonorth.slack
+
+import gonorth.*
+import gonorth.domain.location
+import kategory.Option
+import kategory.getOrElse
+import kategory.nonEmpty
+import org.junit.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+
+class SimpleGameClientTest {
+
+    val goNorth = GoNorth()
+    val gameClient: GameClient = SimpleGameClient(emptyMap(), goNorth, SimpleWorldGenerator())
+
+    @Test
+    fun createShouldCreateANewGameWhenGivenValidInput() {
+        val user = "Dave"
+        val gameStateOption: GameState = gameClient.startGame(user)
+
+        assertTrue { gameStateOption.preText.preText.isNotEmpty() }
+        assertTrue { gameStateOption.preText.description.nonEmpty() }
+    }
+
+    @Test
+    fun takeInputShouldMoveThePlayerWhenGivenAValidDirection() {
+        val user = "Jones"
+        val textOpt = "NORTH"
+        val createdGame: GameState = gameClient.startGame(user)
+        val resultOpt: Option<GameState> = gameClient.takeInput(user, textOpt)
+        val result = resultOpt.getOrElse { createdGame }
+
+        assertTrue { resultOpt.nonEmpty() }
+        assertNotEquals(createdGame, result)
+
+        val initialText = createdGame.preText
+        val resultText = result.preText
+
+        assertTrue(resultText.preText.isNotEmpty())
+        assertNotEquals(initialText.preText, resultText.preText)
+        assertNotEquals(initialText.description, resultText.description)
+        assertTrue(resultText.description.getOrElse { "" }.isNotEmpty())
+        assertNotEquals(resultText.preText, resultText.description.getOrElse { "" })
+
+        assertNotEquals(createdGame.location(), result.location())
+    }
+
+}
+


### PR DESCRIPTION
The `SlackServer` and `SimpleGameClient` need to support two part actions (action + target) in order to support more complex interactions. This PR adds support for `Describe`, which is probably the simplest action that requires a target. 