### PR TITLE
Improved handling of item descriptions

### DIFF
--- a/src/main/kotlin/gonorth/Client.kt
+++ b/src/main/kotlin/gonorth/Client.kt
@@ -2,7 +2,6 @@ package gonorth
 
 import gonorth.domain.*
 import kategory.Option
-import kategory.getOrElse
 import java.util.*
 
 interface GameClient {

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -20,18 +20,19 @@ class GoNorth {
     }
 
     private fun handleMovement(gameState: GameState, move: Move): Option<GameState> {
-        val location: Option<Link> = gameState.locationOpt()
+        val linkToNewLocation: Option<Link> = gameState.locationOpt()
                 .flatMap { gameState.fetchLinks(it.id) }
                 .flatMap { it.find { it.move == move }.toOpt() }
 
-        val newPlace = location.flatMap { l ->
+        val newPlace = linkToNewLocation.flatMap { l ->
             gameState.findLocation(l.to) }
                 .map { it.description }
 
-        return location
+        return linkToNewLocation
                 .map { (id, _, preText) -> gameState.copy(
                         gameText = GameText(preText, newPlace),
                         currentLocation = id) }
+                .map { it.updateTextWithItems() }
     }
 
     private fun describe(gameState: GameState, target: String): GameState {
@@ -63,3 +64,4 @@ class GoNorth {
     }
 
 }
+

--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -50,9 +50,11 @@ class GoNorth {
                 .map { gameState.removeItem(it.name).addToInventory(it) }
                 .getOrElse { gameState }
 
-        val text = GameText( "You take the $target" , Option.Some(""))
+        val descriptionOpt = gsWithItem.locationOpt().map { it.description }
+        val text = GameText( "You take the $target" , descriptionOpt)
 
         return gsWithItem.copy(gameText = text)
+                .updateTextWithItems()
     }
 
     private fun use(gameState: GameState, target: String): GameState {

--- a/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
+++ b/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
@@ -18,36 +18,39 @@ fun GameState.fetchLinks(uuid: UUID): Option<Set<Link>> =
         this.world.links[uuid].toOpt()
 
 fun GameState.findLocation(uuid: UUID): Option<Location> =
-        this.world.locations.find { it.id == uuid}.toOpt()
+        this.world.locations.find { it.id == uuid }.toOpt()
 
 fun GameState.findItem(target: String): Option<Item> =
-        this.locationOpt().flatMap { it.items.find { it.name.equals(target, ignoreCase = true) }.toOpt()}
+        this.locationOpt().flatMap { it.items.find { it.name.equals(target, ignoreCase = true) }.toOpt() }
 
 
 fun GameState.removeItem(target: String): GameState =
         this.copy(world = this.world.copy(locations =
-            this.world.locations.map {
-                it.copy(items = it.items.filterNot { it.name.equals(target, ignoreCase = true) }.toSet())}
-                    .toSet()))
+        this.world.locations.map {
+            it.copy(items = it.items.filterNot { it.name.equals(target, ignoreCase = true) }.toSet())
+        }
+                .toSet()))
 
 fun GameState.addToInventory(item: Item): GameState =
-    this.copy(player = this.player.copy(inventory = this.player.inventory.plus(item)))
+        this.copy(player = this.player.copy(inventory = this.player.inventory.plus(item)))
 
 
 // Drescriptive
 
 fun GameState.updateTextWithItems(): GameState {
     val items = this.locationOpt()
-                .map { it.items }
-                .getOrElse { emptySet() }
+            .map { it.items }
+            .getOrElse { emptySet() }
 
 
     val newDescr: Option<GameText> = this.gameText.description.map {
         items.fold(it) { d, i ->
             d.replace("{${i.name}}", i.ingameText, ignoreCase = true)
         }
-    }.map{ d -> GameText(this.gameText.preText, Option.Some(d))}
+    }
+            .map { it.replace(Regex(pattern = """[{]\w*[}]"""), "") }
+            .map { d -> GameText(this.gameText.preText, Option.Some(d)) }
 
 
-    return newDescr.foldL(this, {gs, gt -> gs.copy(gameText = gt)})
+    return newDescr.foldL(this, { gs, gt -> gs.copy(gameText = gt) })
 }

--- a/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
+++ b/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
@@ -2,6 +2,7 @@ package gonorth.domain
 
 import gonorth.toOpt
 import kategory.Option
+import kategory.getOrElse
 import java.util.*
 
 fun GameState.location(): Location? {
@@ -31,3 +32,22 @@ fun GameState.removeItem(target: String): GameState =
 
 fun GameState.addToInventory(item: Item): GameState =
     this.copy(player = this.player.copy(inventory = this.player.inventory.plus(item)))
+
+
+// Drescriptive
+
+fun GameState.updateTextWithItems(): GameState {
+    val items = this.locationOpt()
+                .map { it.items }
+                .getOrElse { emptySet() }
+
+
+    val newDescr: Option<GameText> = this.gameText.description.map {
+        items.fold(it) { d, i ->
+            d.replace("{${i.name}}", i.ingameText, ignoreCase = true)
+        }
+    }.map{ d -> GameText(this.gameText.preText, Option.Some(d))}
+
+
+    return newDescr.foldL(this, {gs, gt -> gs.copy(gameText = gt)})
+}

--- a/src/main/kotlin/gonorth/domain/GameStateGenerator.kt
+++ b/src/main/kotlin/gonorth/domain/GameStateGenerator.kt
@@ -10,14 +10,16 @@ interface GameStateGenerator {
 
 class SimpleGameStateGenerator : GameStateGenerator {
     override fun generate(player: Player, seed:Long): GameState {
-        val key = Item("Key", "Shiny key, looks useful", "A key rests on the ground.")
+        val key = Item("Key", "Shiny key, looks useful",
+                " except for a small golden key")
 
         val p1 = Location(UUID.randomUUID(), "There is a fork in the path.", emptySet())
         val p2 = Location(UUID.randomUUID(), "The path comes to an abrupt end.", emptySet())
         val p3 = Location(UUID.randomUUID(), "You went north and died.", emptySet())
         val p4 = Location(UUID.randomUUID(),
                 "The road continues to the west, whilst a side path heads south.", emptySet())
-        val p5 = Location(UUID.randomUUID(), "A river blocks your path.", setOf(key))
+        val p5 = Location(UUID.randomUUID(), "You come to an opening in the forest. " +
+                "The path is green with moss{key}. A large river blocks your path.", setOf(key))
         val p6 = Location(UUID.randomUUID(), "To the north you spot a large tower.", emptySet())
         val p7 = Location(UUID.randomUUID(),
                 "You look at the tower door in front of you. Rocks fall, You die.", emptySet())

--- a/src/main/kotlin/gonorth/slack/SlackService.kt
+++ b/src/main/kotlin/gonorth/slack/SlackService.kt
@@ -20,11 +20,6 @@ class SlackService(private val client: GameClient) {
                     SlackResponse(g.gameText.preText + nl +
                             g.gameText.description.map { it + nl }.getOrElse { empty } +
                             g.locationOpt().map { it.description.plus(nl) }.getOrElse { empty } +
-                            g.locationOpt().map {
-                                it.items
-                                        .map { it.name }.fold(empty, { a, b -> a + nl + b })
-                            }
-                                    .getOrElse { empty } +
                             mvs)
                 }
     }
@@ -42,21 +37,13 @@ class SlackService(private val client: GameClient) {
 
                     if (mvs.isEmpty()) {
                         SlackResponse(g.gameText.preText + nl +
-                                g.gameText.description.map { it + nl }.getOrElse { empty } +
-                                g.locationOpt().map {
-                                    it.items
-                                            .map { it.ingameText }.fold(empty, { a, b -> a + b })
-                                }
-                                        .getOrElse { empty })
+                                g.gameText.description.map { it + nl }.getOrElse { empty })
                     } else {
                         SlackResponse(g.gameText.preText + nl +
-                                g.gameText.description.map { it + nl }.getOrElse { empty } +
-                                g.locationOpt().map {
-                                    it.items
-                                            .map { it.ingameText }.fold(empty, { a, b -> a + b })
-                                }
-                                        .getOrElse { empty } + nl +
-                                mvs)
+                                g.gameText.description.map { it + nl }.getOrElse { empty }
+                                + nl
+                                + mvs
+                                )
                     }
                 }
     }

--- a/src/test/kotlin/gonorth/GoNorthTest.kt
+++ b/src/test/kotlin/gonorth/GoNorthTest.kt
@@ -4,6 +4,7 @@ import gonorth.domain.*
 import gonorth.domain.Move.*
 import kategory.Option
 import kategory.getOrElse
+import kategory.nonEmpty
 import kategory.some
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -113,10 +114,14 @@ class GoNorthTest {
         assertEquals(Option.Some(TestConstants.key), gameState.findItem(KEY))
 
         val newState = goNorth.takeAction(TestConstants.gameState, TAKE, KEY.some())
+        val newDescription = newState.gameText.description.getOrElse { "" }
 
         assertEquals(Option.None, newState.findItem(KEY), "The key is removed")
         assertTrue(newState.player.inventory.contains(TestConstants.key), "The player now has the key")
-
+        assertTrue(newState.gameText.description.nonEmpty())
+        assertFalse(newDescription.contains("key", ignoreCase = true))
+        assertEquals("You seem to be in a test. You spot some null pointers to the west. " +
+                "An alternative path heads to the east", newDescription)
     }
 
     @Test

--- a/src/test/kotlin/gonorth/GoNorthTest.kt
+++ b/src/test/kotlin/gonorth/GoNorthTest.kt
@@ -21,7 +21,7 @@ class GoNorthTest {
     @Test
     fun thePlayerStartsAtTheStartingPlace() {
         assertTrue(gameState.gameText.preText == "You venture into a dark dungeon")
-        assertTrue(gameState.location()?.description == "Starting to")
+        assertFalse(gameState.location()?.description.isNullOrBlank())
     }
 
     @Test

--- a/src/test/kotlin/gonorth/TestConstants.kt
+++ b/src/test/kotlin/gonorth/TestConstants.kt
@@ -16,10 +16,10 @@ object TestConstants {
     val location3UUID = UUID.fromString(UUID3)!!
 
 
-    val key = Item("Key", "It's a shiny golden key.", "A shiny key is on the floor.")
+    val key = Item("Key", "It's a shiny golden key.", "A shiny key is on the floor. ")
 
     val location1 = Location(startingLocationUUID,
-            "You seem to be in a test. You spot some null pointers to the west. {key} " +
+            "You seem to be in a test. You spot some null pointers to the west. {key}" +
                     "An alternative path heads to the east", setOf(key))
     val location2 = Location(location2UUID, "You went north and died", emptySet())
     val location3 = Location(location3UUID, "and won!", emptySet())

--- a/src/test/kotlin/gonorth/TestConstants.kt
+++ b/src/test/kotlin/gonorth/TestConstants.kt
@@ -18,7 +18,9 @@ object TestConstants {
 
     val key = Item("Key", "It's a shiny golden key.", "A shiny key is on the floor.")
 
-    val location1 = Location(startingLocationUUID, "Starting to", setOf(key))
+    val location1 = Location(startingLocationUUID,
+            "You seem to be in a test. You spot some null pointers to the west. {key} " +
+                    "An alternative path heads to the east", setOf(key))
     val location2 = Location(location2UUID, "You went north and died", emptySet())
     val location3 = Location(location3UUID, "and won!", emptySet())
 

--- a/src/test/kotlin/gonorth/domain/GameStateExtensionsTest.kt
+++ b/src/test/kotlin/gonorth/domain/GameStateExtensionsTest.kt
@@ -1,18 +1,12 @@
 package gonorth.domain
 
 import gonorth.TestConstants
-import gonorth.domain.location
-import gonorth.domain.locationOpt
 import gonorth.world.WorldBuilder
 import kategory.Option
 import kategory.getOrElse
 import kategory.nonEmpty
 import org.junit.Test
-import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class GameStateExtensionsTest {
 
@@ -86,6 +80,23 @@ class GameStateExtensionsTest {
 
         assertNotNull(newState.player.inventory.firstOrNull{it.name == test})
         assertNull(gameState.player.inventory.firstOrNull{it.name == test})
+    }
+
+    @Test fun canUpdateGameTextForANewLocation() {
+        val gameStateWithDescription = gameState.copy(
+                gameText = GameText("Pre is irrelevant",
+                description = Option.Some(TestConstants.location1.description)))
+
+        val newState:GameState = gameStateWithDescription.updateTextWithItems()
+
+        assertNotNull(newState.gameText.preText)
+        assertTrue(gameStateWithDescription.gameText.description.nonEmpty(), "Should have description")
+        assertTrue(newState.gameText.description.nonEmpty(), "Should have description")
+
+        val preText = newState.gameText.preText
+        val description = newState.gameText.description.getOrElse { "" }
+        assertFalse(preText.contains("A shiny key is on the floor."))
+        assertTrue(description.contains("A shiny key is on the floor."))
     }
 
 }

--- a/src/test/kotlin/gonorth/domain/GameStateExtensionsTest.kt
+++ b/src/test/kotlin/gonorth/domain/GameStateExtensionsTest.kt
@@ -82,10 +82,10 @@ class GameStateExtensionsTest {
         assertNull(gameState.player.inventory.firstOrNull{it.name == test})
     }
 
-    @Test fun canUpdateGameTextForANewLocation() {
+    @Test fun canIncludeItemsWithinTheDescription() {
         val gameStateWithDescription = gameState.copy(
                 gameText = GameText("Pre is irrelevant",
-                description = Option.Some(TestConstants.location1.description)))
+                        description = Option.Some(TestConstants.location1.description)))
 
         val newState:GameState = gameStateWithDescription.updateTextWithItems()
 
@@ -97,6 +97,25 @@ class GameStateExtensionsTest {
         val description = newState.gameText.description.getOrElse { "" }
         assertFalse(preText.contains("A shiny key is on the floor."))
         assertTrue(description.contains("A shiny key is on the floor."))
+    }
+
+    @Test fun willRemoveAnyUnmatchedItems() {
+        val gameStateWithDescription = gameState.copy(
+                gameText = GameText("Pre is irrelevant",
+                        description = Option.Some("There is a table apples, {fork}and some shoes")))
+
+
+        val newState:GameState = gameStateWithDescription.updateTextWithItems()
+
+        assertNotNull(newState.gameText.preText)
+        assertTrue(gameStateWithDescription.gameText.description.nonEmpty(), "Should have description")
+        assertTrue(newState.gameText.description.nonEmpty(), "Should have description")
+
+        val oldDescription = gameStateWithDescription.gameText.description.getOrElse { "" }
+        val newDescription = newState.gameText.description.getOrElse { "" }
+
+        assertEquals("There is a table apples, {fork}and some shoes", oldDescription)
+        assertEquals("There is a table apples, and some shoes", newDescription)
     }
 
 }


### PR DESCRIPTION
Enable injecting of item descriptions. This allow for a more seamless integration and avoids giving away the identities of all interactables.

## Previous behaviour:

Location Description: "On the desk is a pen, pencil, and some paper."
Item: "There is an eraser."
Result: "On the desk is a pen, pencil, and some paper.  There is an old eraser."
On removal: "On the desk is a pen, pencil, and some paper."

## New behaviour:

Location Description: "On the desk is a pen, { eraser }pencil, and some paper."
Item: "old eraser, "
Result: "On the desk is a pen, old eraser, pencil, and some paper."
On removal: "On the desk is a pen, pencil, and some paper."