### PR TITLE
Initial Hunger Support

### DIFF
--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -11,8 +11,13 @@ import gonorth.free.InterpreterFactory
 
 class GoNorth(private val interpreterFactory: InterpreterFactory) {
 
-    fun takeAction(gameState: GameState, move: Move, command: Option<String>): GameState =
+    fun takeAction(gameState: GameState, move: Move, command: Option<String>): GameState {
+        return if (gameState.player.alive) {
             handleActionWithTarget(move, gameState, command.getOrElse { "" })
+        } else {
+            gameState
+        }
+    }
 
     private fun handleActionWithTarget(move: Move, gameState: GameState, target: String): GameState = when (move) {
         Move.NORTH -> handleMovement(gameState, move).getOrElse { gameState }

--- a/src/main/kotlin/gonorth/free/GameEffect.kt
+++ b/src/main/kotlin/gonorth/free/GameEffect.kt
@@ -20,6 +20,9 @@ sealed class GameEffect<out A> : HK<GameEffect.F, A> {
     data class OneWayLink(val link: LinkDetails, val text: String) : GameEffect<GameState>()
     data class TwoWayLink(val link: LinkDetails, val returnLink: LinkDetails, val text: String) : GameEffect<GameState>()
 
+    data class IncreaseHunger(val amount: Int) : GameEffect<GameState>()
+    data class ReduceHunger(val amount: Int) : GameEffect<GameState>()
+
     data class LinkDetails(val from: UUID, val to: UUID, val move: Move, val description: String)
 
     companion object : FreeMonadInstance<F> {
@@ -37,5 +40,11 @@ sealed class GameEffect<out A> : HK<GameEffect.F, A> {
 
         fun teleportPlayer(locationUUID: UUID, text: String): FreeEffect =
                 Free.liftF(TeleportPlayer(locationUUID, text))
+
+        fun increaseHunger(amount: Int): FreeEffect =
+                Free.liftF(IncreaseHunger(amount))
+
+        fun reduceHunger(amount: Int): FreeEffect =
+                Free.liftF(ReduceHunger(amount))
     }
 }

--- a/src/main/kotlin/gonorth/free/InterpreterFactory.kt
+++ b/src/main/kotlin/gonorth/free/InterpreterFactory.kt
@@ -56,7 +56,9 @@ class InterpreterFactory() {
                         Id.pure(gs)
                     }
                     is GameEffect.IncreaseHunger -> {
-                        gs = gs.copy(player = gs.player.copy(hunger = gs.player.hunger - op.amount))
+                        val newHunger = gs.player.hunger - op.amount
+                        gs = gs.copy(player = gs.player.copy(hunger = newHunger, alive = newHunger > 0))
+
                         Id.pure(gs)
                     }
                     is GameEffect.ReduceHunger -> {

--- a/src/main/kotlin/gonorth/free/InterpreterFactory.kt
+++ b/src/main/kotlin/gonorth/free/InterpreterFactory.kt
@@ -55,6 +55,14 @@ class InterpreterFactory() {
                         gs = gs.appendDescription(op.text)
                         Id.pure(gs)
                     }
+                    is GameEffect.IncreaseHunger -> {
+                        gs = gs.copy(player = gs.player.copy(hunger = gs.player.hunger - op.amount))
+                        Id.pure(gs)
+                    }
+                    is GameEffect.ReduceHunger -> {
+                        gs = gs.copy(player = gs.player.copy(hunger = Math.min(1000, gs.player.hunger + op.amount)))
+                        Id.pure(gs)
+                    }
                 } as Id<A>
             }
         }

--- a/src/test/kotlin/gonorth/TestConstants.kt
+++ b/src/test/kotlin/gonorth/TestConstants.kt
@@ -32,7 +32,7 @@ object TestConstants {
 
     private val gameText = GameText("You venture into a dark dungeon",
             None)
-    val player = Player(1000, emptySet(), alive = true)
+    val player = Player(900, emptySet(), alive = true)
 
     private val builder = WorldBuilder().newLocation(location1)
             .newLocation(location2)

--- a/src/test/kotlin/gonorth/free/GameEffectInterpreterTest.kt
+++ b/src/test/kotlin/gonorth/free/GameEffectInterpreterTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class ActionInterpreterTest {
+class GameEffectInterpreterTest {
 
     private val actionInterpreter = InterpreterFactory()
     private val gameState = TestConstants.gameState
@@ -125,6 +125,19 @@ class ActionInterpreterTest {
                 .ev().value
 
         assertTrue { result.player.hunger < gameState.player.hunger }
+    }
+
+    @Test
+    fun canKillThePlayerUsingHunger() {
+        val interpreter = actionInterpreter.impureGameEffectInterpreter(gameState)
+        val effect = GameEffect.increaseHunger(10000)
+
+        val result = effect.foldMap(interpreter, Id.monad())
+                .ev().value
+
+        assertTrue { result.player.hunger < gameState.player.hunger }
+        assertTrue { result.player.hunger <= 0 }
+        assertFalse { result.player.alive }
     }
 
     @Test

--- a/src/test/kotlin/gonorth/free/InterpreterTest.kt
+++ b/src/test/kotlin/gonorth/free/InterpreterTest.kt
@@ -16,8 +16,8 @@ import kotlin.test.assertTrue
 
 class ActionInterpreterTest {
 
-    val actionInterpreter = InterpreterFactory()
-    val gameState = TestConstants.gameState
+    private val actionInterpreter = InterpreterFactory()
+    private val gameState = TestConstants.gameState
 
     @Test
     fun canIncludeADescription() {
@@ -114,5 +114,39 @@ class ActionInterpreterTest {
 
         assertTrue { result.gameText.description.exists { it.contains("You explode") } }
         assertFalse { result.player.alive }
+    }
+
+    @Test
+    fun canMakeThePlayerHungry() {
+        val interpreter = actionInterpreter.impureGameEffectInterpreter(gameState)
+        val effect = GameEffect.increaseHunger(10)
+
+        val result = effect.foldMap(interpreter, Id.monad())
+                .ev().value
+
+        assertTrue { result.player.hunger < gameState.player.hunger }
+    }
+
+    @Test
+    fun canSatiateThePlayer() {
+        val interpreter = actionInterpreter.impureGameEffectInterpreter(gameState)
+        val effect = GameEffect.reduceHunger(10)
+
+        val result = effect.foldMap(interpreter, Id.monad())
+                .ev().value
+
+        assertTrue { result.player.hunger > gameState.player.hunger }
+    }
+
+    @Test
+    fun cannotSatiateThePlayerOverTheLimit() {
+        val interpreter = actionInterpreter.impureGameEffectInterpreter(gameState)
+        val effect = GameEffect.reduceHunger(10000)
+
+        val result = effect.foldMap(interpreter, Id.monad())
+                .ev().value
+
+        assertTrue { result.player.hunger > gameState.player.hunger }
+        assertTrue { result.player.hunger == 1000 }
     }
 }


### PR DESCRIPTION
Since the idea is to present options and not interpret text, there should be a mechanic to limit to limit the number of turns a player can make.  As this is meant to be an engine and not an implementation, this may be renamed in a later change to `timeLimit` or something more generic.