### PR TITLE
Move more logic out of GoNorth

### DIFF
--- a/src/main/kotlin/gonorth/GoNorth.kt
+++ b/src/main/kotlin/gonorth/GoNorth.kt
@@ -4,8 +4,6 @@ import arrow.core.*
 import arrow.free.Free
 import arrow.free.flatMap
 import arrow.free.foldMap
-import arrow.syntax.collections.firstOption
-import arrow.syntax.monad.flatten
 import arrow.syntax.option.some
 import arrow.syntax.option.toOption
 import gonorth.domain.*
@@ -67,7 +65,7 @@ class GoNorth(private val interpreterFactory: InterpreterFactory) {
     private fun take(gameState: GameState, target: String): GameState {
         val gameStateAfterTakingItem: Option<GameState> = gameState.moveItemToInventory(target)
 
-        val descriptionOpt = gameStateAfterTakingItem.flatMap { it.currentDescription() }
+        val descriptionOpt = gameStateAfterTakingItem.getOrElse { gameState }.currentDescription()
 
         return gameStateAfterTakingItem
                 .map { g -> g.updateGameText("You take the $target", descriptionOpt) }

--- a/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
+++ b/src/main/kotlin/gonorth/domain/GameStateExtensions.kt
@@ -1,7 +1,10 @@
 package gonorth.domain
 
 import arrow.core.Option
+import arrow.core.ev
 import arrow.core.getOrElse
+import arrow.syntax.collections.firstOption
+import arrow.syntax.monad.flatten
 import arrow.syntax.option.toOption
 import java.util.*
 
@@ -13,6 +16,9 @@ fun GameState.location(): Location? {
 
 fun GameState.locationOpt(): Option<Location> =
         this.location().toOption()
+
+fun GameState.currentDescription(): Option<String> =
+        this.locationOpt().map{ it.description }
 
 fun GameState.fetchLinks(uuid: UUID): Option<Set<Link>> =
         this.world.links[uuid].toOption()
@@ -33,6 +39,20 @@ fun GameState.findItem(target: String): Option<Item> =
 fun GameState.findUsable(target: String): Option<Useable> =
         this.locationOpt().flatMap { it.items.findUsable(target) }
 
+fun GameState.findUsableInCurrentLocation(target:String): Option<Useable> =
+    this.locationOpt()
+            .flatMap { it.items.findUsable(target) }
+
+fun GameState.findUsableInInventory(target:String): Option<Useable> =
+    this.player.inventory.findUsable(target)
+
+fun GameState.findPossibleUseable(target:String): Option<Useable> {
+    val worldItem = this.findUsableInCurrentLocation(target)
+    val item = this.findUsableInInventory(target)
+    return listOf(worldItem, item).firstOption { it.nonEmpty() }.flatten().ev()
+}
+
+
 fun Collection<Useable>.findUsable(target: String): Option<Useable> =
         this.find {
             when (it) {
@@ -41,7 +61,7 @@ fun Collection<Useable>.findUsable(target: String): Option<Useable> =
             }
         }.toOption()
 
-fun Useable.name(): String = when(this) {
+fun Useable.name(): String = when (this) {
     is Item -> this.name
     is FixedItem -> this.name
 }
@@ -94,20 +114,27 @@ fun GameState.updateTextWithItems(): GameState {
     return newDescr.foldLeft(this, { gs, gt -> gs.copy(gameText = gt) })
 }
 
-fun GameState.appendDescription(textToAppend: String): GameState {
-    return this.copy(gameText = this.gameText.copy(description =
-    Option(this.gameText.description.map { desc -> desc + "\n" + textToAppend }
-            .getOrElse { textToAppend })))
-}
+fun GameState.appendDescription(textToAppend: String): GameState =
+        this.copy(gameText = this.gameText.copy(description =
+        Option(this.gameText.description.map { desc -> desc + "\n" + textToAppend }
+                .getOrElse { textToAppend })))
 
-fun GameState.appendPretext(textToAppend: String): GameState {
-    return this.copy(gameText = this.gameText.copy(preText =
-    if (this.gameText.preText.isBlank()) textToAppend
-    else this.gameText.preText + "\n" + textToAppend))
-}
 
-fun GameState.resetGameText(): GameState {
-    return this.copy(gameText = this.gameText.copy(preText = "", description = this.locationOpt().map { it.description }))
-            .updateTextWithItems()
-}
+fun GameState.appendPretext(textToAppend: String): GameState =
+        this.copy(gameText =
+        this.gameText.copy(preText =
+        if (this.gameText.preText.isBlank()) textToAppend
+        else this.gameText.preText + "\n" + textToAppend))
+
+
+fun GameState.resetGameText(): GameState =
+        this.copy(gameText = this.gameText.copy(preText = "", description = this.locationOpt().map { it.description }))
+                .updateTextWithItems()
+
+fun GameState.updateGameText(preText:String, description: Option<String>): GameState =
+        this.copy(gameText = GameText(preText, description))
+
+fun GameState.moveItemToInventory(target: String): Option<GameState> =
+        this.findItem(target)
+                .map { this.removeItem(it.name).addToInventory(it) }
 


### PR DESCRIPTION
GoNorth class is rather complex and has logic that probably could be held elsewhere to enable reuse and easier testing.

At the same time it might be sensible to break up `GameStateExtensions` into subclasses. Perhaps into methods for specific domains: LocationExtensions, ItemExtensions, etc